### PR TITLE
Bug fix and new --clean option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Updated `CHANGELOG.md` to move unreleased into `v0.0.2`.
+- Changed approach to detecting Zoom on Mac.
 
 ## [v0.0.2] - 2018-11-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added `zoom_slack --clean` to clean any compiled scripts.
+
 ### Changed
 - Updated `CHANGELOG.md` to move unreleased into `v0.0.2`.
 - Changed approach to detecting Zoom on Mac.

--- a/bin/zoom_slack
+++ b/bin/zoom_slack
@@ -44,6 +44,12 @@ OptionParser.new do |opts|
   opts.separator ""
   opts.separator "Common options:"
 
+  opts.on("--clean",
+          "Clean compiled scripts") do
+    ZoomSlack::ProcessDetector.for_platform.clean
+    exit
+  end
+
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
     exit

--- a/lib/zoom_slack/process_detector/base.rb
+++ b/lib/zoom_slack/process_detector/base.rb
@@ -11,6 +11,10 @@ module ZoomSlack
       def running?
         raise NotImplementedError
       end
+
+      def clean
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/zoom_slack/process_detector/mac.rb
+++ b/lib/zoom_slack/process_detector/mac.rb
@@ -18,6 +18,10 @@ module ZoomSlack
         process_running?
       end
 
+      def clean
+        FileUtils.remove_dir(compiled_path) if Dir.exist?(compiled_path)
+      end
+
       private
 
       attr_accessor :open

--- a/lib/zoom_slack/process_detector/source/in_zoom_meeting.applescript
+++ b/lib/zoom_slack/process_detector/source/in_zoom_meeting.applescript
@@ -1,11 +1,9 @@
 tell application "System Events"
-    try
-        if exists (window 2 of process "zoom.us") then
-            #do shell script "~/bin/update_slack_status meeting"
-            return true 
-        else
-            #do shell script "~/bin/update_slack_status clear"
-            return false
-        end if
-    end try
+	set openWindows to item 1 of (get the {title} of every window of (every process whose visible is true))
+
+	repeat with theCurrentListItem in openWindows
+		if (theCurrentListItem as string) starts with "Zoom Meeting ID" then return true
+	end repeat
 end tell
+
+return false

--- a/spec/zoom_slack/process_detector/base_spec.rb
+++ b/spec/zoom_slack/process_detector/base_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe ZoomSlack::ProcessDetector::Base do
       expect { subject.running? }.to raise_error(NotImplementedError)
     end
   end
+
+  describe "#clean" do
+    it "should raise exception" do
+      expect { subject.clean }.to raise_error(NotImplementedError)
+    end
+  end
 end

--- a/spec/zoom_slack/process_detector/mac_spec.rb
+++ b/spec/zoom_slack/process_detector/mac_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe ZoomSlack::ProcessDetector::Mac do
     Dir.mkdir(compiled_path) unless Dir.exist?(compiled_path)
   end
 
+  describe "#clean" do
+    it "removes compiled directory" do
+      make_compiled
+      subject.clean
+
+      expect(Dir.exist?(compiled_path)).to be_falsey
+    end
+  end
+  
   describe "#running?" do
     describe "compiling the source script" do
       before do


### PR DESCRIPTION
Changes the approach to detecting Zoom on Mac.  Instead of looking for at least 2 zoom windows, look for a window with a title starting with `Zoom Meeting ID`.

Also added a new `--clean` option to the binary to clean out compiled sources.